### PR TITLE
make cast use Number for rowid and pass schema instead of definition

### DIFF
--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -344,7 +344,7 @@ module.exports = (function() {
         }
 
         // Build a query object
-        var _query = new Query(dbs[table].definition);
+        var _query = new Query(dbs[table].schema);
 
         // Escape table name
         table = utils.escapeTable(table);

--- a/lib/query.js
+++ b/lib/query.js
@@ -515,7 +515,13 @@ Query.prototype.cast = function(values) {
   Object.keys(values).forEach(function(key) {
 
     // Lookup schema type
-    var type = self._schema[key].type;
+    var type = "";
+
+    if (key == 'rowid') {
+      type = 'Number';
+    } else {
+      self._schema[key].type;
+    }
     if(!type) return;
 
     // Attempt to parse Array


### PR DESCRIPTION
definition is null for some reason but schema has my schema and Query wants a schema.

My db has no rowid in its schema.
